### PR TITLE
Use JSON API for chromedriver versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 # Dependencies
 
 - `bash`, `curl`, `zip`: generic POSIX utilities.
-- `jq`: used to parse JSON for versions
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 # Dependencies
 
 - `bash`, `curl`, `zip`: generic POSIX utilities.
+- `jq`: used to parse JSON for versions
 
 # Install
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -34,7 +34,12 @@ sort_versions() {
 }
 
 list_all_versions() {
-  curl -s "$SOURCE" | jq -r '.versions[].version' | sort_versions
+  curl -s "$SOURCE" \
+    | sed 's/[,\[]/\n/g' \
+    | sed 's/{//g' \
+    | grep '"version":' \
+    | sed 's/"version":"\(.*\)"/\1/g' \
+    | sort_versions
 }
 
 release_url() {


### PR DESCRIPTION
This is a brute-force attempt to solve #2.

I'm not sure if you want to accept it as-is, because of the implicit dependency on `jq`. Also, it appears as if the new JSON endpoint only starts including chromedriver as of version `115.0.5763.0`, which works for my needs but doesn't seem ideal.

Also note that the zip files listed in this endpoint have all of their contents internally listed at `chromedriver-${platform}/*`, rather than at `bin/*`.

At the very least, hopefully this is helpful to you as a starting point.